### PR TITLE
Add count to check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ This repository currently contains only the basic scaffolding:
 - CLI commands implemented with `clap`
 - Configuration loading from a platform specific location
 - Stubs for future IMAP/SMTP integration
+- The `check` command prints the number of new emails to stdout
 
 Run `cargo run --help` for available commands.

--- a/spec/rustmail_design_doc.md
+++ b/spec/rustmail_design_doc.md
@@ -20,11 +20,13 @@
 ## 🧰 CLI Commands
 
 ### `check`
-Check for new/unread mail in the default or specified folder.
+Check for new/unread mail in the default or specified folder. The command prints
+the number of new messages to standard output.
 
 ```bash
 rustmail check
 rustmail check inbox
+# prints the number of new emails (e.g. `3`)
 ```
 
 ### `list [<folder>] [--limit N] [--offset N]`

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,8 @@ fn check_mail(folder: Option<String>) -> anyhow::Result<()> {
         }
     }
 
+    println!("{}", uids.len());
+
     session.logout()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- print the number of new messages in `check` command
- document the new behavior in the design doc and README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68430285a4908332bfea1230703c69b9