### PR TITLE
Refactor mail functions into modules

### DIFF
--- a/src/mail/auth.rs
+++ b/src/mail/auth.rs
@@ -1,0 +1,6 @@
+use crate::config;
+
+/// Fetch the account password using the configured command.
+pub fn get_password(cmd: &str) -> anyhow::Result<String> {
+    config::retrieve_password(cmd)
+}

--- a/src/mail/imap.rs
+++ b/src/mail/imap.rs
@@ -1,0 +1,38 @@
+use imap::{ClientBuilder, TlsKind};
+
+use crate::config;
+use super::auth::get_password;
+use super::storage::store_message;
+
+/// Connect to the IMAP server and check for new/unread mail.
+/// Any new messages are stored locally and the count is printed to stdout.
+pub fn check_mail(folder: Option<String>) -> anyhow::Result<()> {
+    let cfg = config::load_config()?;
+    let account = cfg.email_account;
+    let folder = folder
+        .or_else(|| account.default_folder.clone())
+        .unwrap_or_else(|| "inbox".to_string());
+
+    let password = get_password(&account.password_cmd)?;
+    let client = ClientBuilder::new(&account.imap_server, account.imap_port)
+        .tls_kind(TlsKind::Native)
+        .connect()?;
+    let mut session = client.login(&account.username, password).map_err(|e| e.0)?;
+
+    session.select(&folder)?;
+    let uids = session.search("UNSEEN")?;
+    for uid in uids.iter() {
+        let fetches = session.fetch(uid.to_string(), "RFC822")?;
+        for fetch in fetches.iter() {
+            if let Some(body) = fetch.body() {
+                let uid = fetch.uid.ok_or_else(|| anyhow::anyhow!("missing uid"))?;
+                store_message(&account, &folder, uid, body)?;
+            }
+        }
+    }
+
+    println!("{}", uids.len());
+
+    session.logout()?;
+    Ok(())
+}

--- a/src/mail/mod.rs
+++ b/src/mail/mod.rs
@@ -1,0 +1,3 @@
+pub mod auth;
+pub mod storage;
+pub mod imap;

--- a/src/mail/storage.rs
+++ b/src/mail/storage.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+use sha1::{Digest, Sha1};
+
+use crate::config;
+
+/// Store an email message body to disk and return the file path.
+pub fn store_message(
+    account: &config::EmailAccount,
+    folder: &str,
+    uid: u32,
+    body: &[u8],
+) -> anyhow::Result<PathBuf> {
+    let mut hasher = Sha1::new();
+    hasher.update(folder.as_bytes());
+    hasher.update(uid.to_string().as_bytes());
+    let id = hex::encode(hasher.finalize());
+
+    let mut dir = config::account_data_dir(&account.email);
+    dir.push(folder);
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(format!("{}.eml", id));
+    std::fs::write(&path, body)?;
+    log::info!("Saved message {} to {:?}", uid, path);
+    Ok(path)
+}


### PR DESCRIPTION
## Summary
- create `mail` module with `auth`, `storage`, and `imap` submodules
- move `get_password`, `store_message`, and `check_mail` into their respective modules
- update main program to use new module paths

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684308b012dc8332b18f2bc4ec05f250