### PR TITLE
Create config and data directories if missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "native-tls",
  "serde",
  "sha1",
+ "tempfile",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ imap = { version = "3.0.0-alpha.15", default-features = false, features = ["nati
 native-tls = "0.2"
 sha1 = "0.10"
 hex = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/mail/storage.rs
+++ b/src/mail/storage.rs
@@ -16,7 +16,7 @@ pub fn store_message(
     hasher.update(uid.to_string().as_bytes());
     let id = hex::encode(hasher.finalize());
 
-    let mut dir = config::account_data_dir(&account.email);
+    let mut dir = config::account_data_dir(&account.email)?;
     dir.push(folder);
     std::fs::create_dir_all(&dir)?;
     let path = dir.join(format!("{}.eml", id));


### PR DESCRIPTION
## Summary
- create example config file when none exists
- ensure account data directories are automatically created
- update tests for new behavior

## Testing
- `cargo test --quiet`
- `XDG_CONFIG_HOME=/tmp/rustmail_test cargo run --quiet -- check` (creates config then errors on password)

------
https://chatgpt.com/codex/tasks/task_e_68444ce9eb548332a2d588f6a592def2